### PR TITLE
Bump to Ruby 2.6.3

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source 'https://rubygems.org'
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
-ruby '2.6.2'
+ruby '2.6.3'
 
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
 gem 'rails', '~> 5.2.2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -226,7 +226,7 @@ DEPENDENCIES
   web-console (>= 3.3.0)
 
 RUBY VERSION
-   ruby 2.6.2p47
+   ruby 2.6.3p62
 
 BUNDLED WITH
    1.17.3


### PR DESCRIPTION
Ruby 2.6.3 has been [released](https://www.ruby-lang.org/en/news/2019/04/17/ruby-2-6-3-released/).