### PR TITLE
Bump rubocop-shopify

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -9,6 +9,7 @@ AllCops:
     - bin/*
     - db/**/*
     - vendor/bundle/**/*
+  NewCops: enable
 
 Bundler/OrderedGems:
   Enabled: true

--- a/Gemfile
+++ b/Gemfile
@@ -8,6 +8,7 @@ gem 'carrierwave'
 gem 'coffee-rails'
 gem 'jbuilder'
 gem 'mini_magick'
+gem 'msgpack', '~> 1.4'
 gem 'puma'
 gem 'rails'
 gem 'rubocop'
@@ -15,7 +16,6 @@ gem 'sass-rails'
 gem 'turbolinks'
 gem 'tzinfo-data'
 gem 'uglifier'
-gem 'msgpack', '~> 1.4'
 
 group :development, :test do
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]

--- a/Gemfile
+++ b/Gemfile
@@ -26,7 +26,7 @@ group :development do
   gem 'pry'
   gem 'rubocop-performance'
   gem 'rubocop-rails'
-  gem 'rubocop-shopify', require: false
+  gem 'rubocop-shopify', '~> 2.0', require: false
   gem 'spring'
   gem 'spring-watcher-listen'
   gem 'sqlite3'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -281,7 +281,7 @@ DEPENDENCIES
   rubocop
   rubocop-performance
   rubocop-rails
-  rubocop-shopify
+  rubocop-shopify (~> 2.0)
   sass-rails
   spring
   spring-watcher-listen


### PR DESCRIPTION
The big `rubocop-shopify` bump (from 1.x to 2.x).