### PR TITLE
Code analysis ignore Dependabot branch pushes

### DIFF
--- a/.github/workflows/brakeman-analysis.yml
+++ b/.github/workflows/brakeman-analysis.yml
@@ -11,6 +11,9 @@ name: Brakeman Scan
 on:
   push:
     branches: [ main ]
+    # Dependabot triggered push events have read-only access, but uploading code
+    # scanning requires write access. Thus, we ignore Dependabot branches.
+    branches-ignore: [dependabot/**]
   pull_request:
     # The branches below must be a subset of the branches above
     branches: [ main ]

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -14,6 +14,9 @@ name: "CodeQL"
 on:
   push:
     branches: [ main ]
+    # Dependabot triggered push events have read-only access, but uploading code
+    # scanning requires write access. Thus, we ignore Dependabot branches.
+    branches-ignore: [dependabot/**]
   pull_request:
     # The branches below must be a subset of the branches above
     branches: [ main ]


### PR DESCRIPTION
Fix issues with Brakeman scans that fail on Dependabot branch pushes, which run as read-only. ([example](https://github.com/larouxn/carrotgram/runs/4627877463?check_suite_focus=true))

Fix based on https://github.com/cisagov/con-pca-api/commit/0d726beaa314e0229af0104fb082232eed1ef54f.