### PR TITLE
Remove SQLite from prod packages since we're on PG

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -64,7 +64,7 @@ RUN if [ -f "yarn.lock" ]; then \
 
 FROM base
 
-ARG PROD_PACKAGES="postgresql-client file vim curl gzip libsqlite3-0 imagemagick"
+ARG PROD_PACKAGES="postgresql-client file vim curl gzip imagemagick"
 ENV PROD_PACKAGES=${PROD_PACKAGES}
 
 RUN --mount=type=cache,id=prod-apt-cache,sharing=locked,target=/var/cache/apt \


### PR DESCRIPTION
Likely no longer need to install libsqlite3-0 on prod machines now that we properly use Postgres in prod.