### PR TITLE
Add rubocop-performance to .rubocop.yml

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,7 +1,9 @@
 inherit_gem:
   rubocop-shopify: rubocop.yml
 
-require: rubocop-rails
+require:
+  - rubocop-performance
+  - rubocop-rails
 
 AllCops:
   TargetRubyVersion: 3.1


### PR DESCRIPTION
Apparently we weren't using this the whole time, just had the gem installed.