### PR TITLE
Upgrade deploy GitHub Action from Node 12 to 16

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -10,6 +10,6 @@ jobs:
     name: Deploy app
     runs-on: ubuntu-latest
     steps:
-        - uses: actions/checkout@v2
+        - uses: actions/checkout@v3
         - uses: superfly/flyctl-actions/setup-flyctl@master
         - run: flyctl deploy --remote-only


### PR DESCRIPTION
According to the following, all we need to do is upgrade the checkout action from v2 to v3.
- https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/
- https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#example-using-versioned-actions

Resolves https://github.com/larouxn/carrotgram/issues/524