### PR TITLE
Lock deploy actions/checkout to v3.5.3

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -10,6 +10,6 @@ jobs:
     name: Deploy app
     runs-on: ubuntu-latest
     steps:
-        - uses: actions/checkout@v3
+        - uses: actions/checkout@v3.5.3
         - uses: superfly/flyctl-actions/setup-flyctl@master
         - run: flyctl deploy --remote-only


### PR DESCRIPTION
Locking to latest version. Part of robustifying deploys.

https://github.com/actions/checkout/releases/tag/v3.5.3