### PR TITLE
Lock flyctl setup action to v1.4

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,4 +12,6 @@ jobs:
     steps:
         - uses: actions/checkout@v3.5.3
         - uses: superfly/flyctl-actions/setup-flyctl@master
+          with:
+            version: 1.4
         - run: flyctl deploy --remote-only


### PR DESCRIPTION
Locking flyctl setup action to v1.4 to robustify deploys.

- https://github.com/superfly/flyctl-actions/tree/5e0688e3d0586e2cad2288e6c49c3e9bedac39e5#pin-to-a-specific-version-of-flyctl
- https://github.com/superfly/flyctl-actions/releases/tag/1.4